### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,9 @@
-# frontend-starter-kit
-![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg) ![Dependencies](https://david-dm.org/olajideoye/frontend-starter-kit.svg)
+# gulp-starter-kit
+![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg) ![Dependencies](https://david-dm.org/olajideoye/gulp-starter-kit.svg)
 
-A simple starter kit for front-end projects based on my experience as a front-end web developer. 
+A simple starter kit with reusable functions for front-end projects using [Gulp.js](https://gulpjs.com).
 
-I've setup this starter kit based on the tools I currently use and love.
-
-
-## What's this project about
-This starter-kit is a way to document a standard approach for myself, and reduce time I spend to set up a new project. Here's what you'll get out of the box:
-
-- An opinionated project folder structure (which can be easily reconfigured)
-- A gulpfile full of useful functions for different tasks
-
-While the list above is great, there are a few things I stayed out of intentionally:
-
-- **A Node.js server**: I stayed out of including a Node.js server because I don't always need one on my projects
-- **Gulp task functions for JavaScript**: I've found that my needs for JavaScript in a project varies widely, from writing simple ES5 files to Express.js apps to writing SPAs and bundling everything together with Webpack and Babel.js. I intend to add a few functions in the future to do things like linting, minification and transpiling code. 
-
+You can simply grab the gulpfile and config file or use the (rather opinionated) folder structure to start building your project.
 
 ## Setup
 #### Install Node.js and NPM
@@ -44,11 +31,10 @@ npm install
 - Better documentation on folder structure and Gulp functions available
 - Linting
 - ES2015 support using Babel.js
-- Bundling using Webpack
 
 
 ## License
-This starter kit is licensed under the MIT license. You can grab it [here](https://github.com/olajideoye/frontend-starter-kit/blob/master/LICENSE)
+This starter kit is licensed under the MIT license. You can grab it [here](https://github.com/olajideoye/gulp-starter-kit/blob/master/LICENSE)
 
 
 ## Credits

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "frontend-starter-kit",
-  "description": "A simple starter kit for front-end projects based on my experience as a front-end web developer.",
+  "name": "gulp-starter-kit",
+  "description": "A simple starter kit with reusable functions for front-end projects using Gulp.",
   "main": "gulpfile.js",
   "authors": [
     "Ọlájídé Oyè <olajide.oye@gmail.com>"
@@ -14,7 +14,7 @@
     "web",
     "development"
   ],
-  "homepage": "https://github.com/olajideoye/frontend-starter-kit",
+  "homepage": "https://github.com/olajideoye/gulp-starter-kit",
   "private": true,
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "frontend-starter-kit",
+  "name": "gulp-starter-kit",
   "version": "0.1.0",
-  "description": "A simple starter kit for front-end projects based on my experience as a front-end web developer.",
+  "description": "A simple starter kit with reusable functions for front-end projects using Gulp.",
   "main": "gulpfile.js",
   "scripts": {
     "start": "./node_modules/.bin/gulp",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/olajideoye/frontend-starter-kit.git"
+    "url": "git+https://github.com/olajideoye/gulp-starter-kit.git"
   },
   "keywords": [
     "starter",
@@ -22,9 +22,9 @@
   "author": "Ọlájídé Oyè <olajide.oye@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/olajideoye/frontend-starter-kit/issues"
+    "url": "https://github.com/olajideoye/gulp-starter-kit/issues"
   },
-  "homepage": "https://github.com/olajideoye/frontend-starter-kit#readme",
+  "homepage": "https://github.com/olajideoye/gulp-starter-kit#readme",
   "dependencies": {
     "autoprefixer": "^6.7.7",
     "bower": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-starter-kit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple starter kit with reusable functions for front-end projects using Gulp.",
   "main": "gulpfile.js",
   "scripts": {


### PR DESCRIPTION
I've renamed the project from 'frontend-starter-kit' to 'gulp-starter-kit' and simplified its scope.